### PR TITLE
Added grafana 7 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         - '--storage.tsdb.path=/prometheus'
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:7.0.0-beta3
     depends_on:
       - prometheus
     ports:


### PR DESCRIPTION
Grafana 7 adds a new set of features that we will explore later. This code updates docker-compose to support the latest beta version available of grafana.